### PR TITLE
Update ABPadLockScreenController.m

### DIFF
--- a/ABPadLockScreen/Controller/ABPadLockScreenController.m
+++ b/ABPadLockScreen/Controller/ABPadLockScreenController.m
@@ -410,4 +410,19 @@ typedef enum {
     return NO;
 }
 
+#pragma mark - Interface orientation for iOS 5
+
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
+{
+    // Return YES for supported orientations
+    if (interfaceOrientation == UIInterfaceOrientationPortrait)
+    {
+        return YES;
+    }else if (interfaceOrientation == UIInterfaceOrientationLandscapeLeft || interfaceOrientation == UIInterfaceOrientationLandscapeRight)  {
+        return YES;
+    }else {
+        return NO;
+    }
+}
+
 @end


### PR DESCRIPTION
This fix will allow the screen to work with iPad applications that have the interface orientation set to Horizontal.
So we don't display the pin screen in a different orientation related to the iPad.
