### PR TITLE
Support for ABPadButton hightlightedTextColor

### DIFF
--- a/ABPadLockScreen/ABPadButton.h
+++ b/ABPadLockScreen/ABPadButton.h
@@ -34,6 +34,7 @@
 @property (nonatomic, strong) UIColor *borderColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor *selectedColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor *textColor UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *hightlightedTextColor UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIFont *numberLabelFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIFont *letterLabelFont UI_APPEARANCE_SELECTOR;
 

--- a/ABPadLockScreen/ABPadButton.m
+++ b/ABPadLockScreen/ABPadButton.m
@@ -94,6 +94,7 @@
     _borderColor = [UIColor whiteColor];
     _selectedColor = [UIColor grayColor];
     _textColor = [UIColor whiteColor];
+    _hightlightedTextColor = [UIColor whiteColor];
     _numberLabelFont = [UIFont systemFontOfSize:30];
     _letterLabelFont = [UIFont systemFontOfSize:10];
 }
@@ -103,7 +104,9 @@
     self.selectedView.backgroundColor = self.selectedColor;
     self.layer.borderColor = [self.borderColor CGColor];
     self.numberLabel.textColor = self.textColor;
+    self.numberLabel.highlightedTextColor = self.hightlightedTextColor;
     self.lettersLabel.textColor = self.textColor;
+    self.lettersLabel.highlightedTextColor = self.hightlightedTextColor;
 }
 
 - (void)performLayout
@@ -123,9 +126,11 @@
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {
     [super touchesBegan:touches withEvent:event];
-    
+
+    __weak ABPadButton *weakSelf = self;
     [UIView animateWithDuration:animationLength delay:0.0f options:UIViewAnimationOptionCurveEaseIn animations:^{
-        self.selectedView.alpha = 1.0f;
+        weakSelf.selectedView.alpha = 1.0f;
+        [weakSelf setHighlighted:YES];
     } completion:nil];
 }
 
@@ -137,13 +142,17 @@
                           delay:0.0f
                         options:UIViewAnimationOptionCurveEaseIn | UIViewAnimationOptionAllowUserInteraction
                      animations:^{
-        weakSelf.selectedView.alpha = 0.0f;
+                         weakSelf.selectedView.alpha = 0.0f;
+                         [weakSelf setHighlighted:NO];
     } completion:nil];
 }
 
 - (void)setHighlighted:(BOOL)highlighted
 {
     [super setHighlighted:highlighted];
+
+    self.numberLabel.highlighted = highlighted;
+    self.lettersLabel.highlighted = highlighted;
 }
 
 #pragma mark -


### PR DESCRIPTION
Add support for `[[ABPadButton appearance] setHightlightedTextColor:]` and transition `numberLabel` / `lettersLabel` during `touchesBegan:` and `touchesEnded:`.

By default, `highlightedTextColor` is the same colour as `textColor`, for backwards compatibility due to the transitions.

This allows for more customization, like making `textColor` and `selectedColor` the same colour, and still be readable when tapped.

![abpadlockscreen-highlight](https://f.cloud.github.com/assets/71955/2522522/338e795e-b4c2-11e3-9dee-07623361d051.png)
