### PR TITLE
fixed issue #26 with screen being too low

### DIFF
--- a/ABPadLockScreen/ABPadLockScreenAbstractViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenAbstractViewController.m
@@ -67,7 +67,7 @@
 {
     [super viewDidLoad];
     
-    self.view = [[ABPadLockScreenView alloc] initWithFrame:self.view.frame complexPin:self.isComplexPin];
+    self.view = [[ABPadLockScreenView alloc] initWithFrame:self.view.bounds complexPin:self.isComplexPin];
     [self setUpButtonMapping];
     [lockScreenView.cancelButton addTarget:self action:@selector(cancelButtonSelected:) forControlEvents:UIControlEventTouchUpInside];
     [lockScreenView.deleteButton addTarget:self action:@selector(deleteButtonSelected:) forControlEvents:UIControlEventTouchUpInside];

--- a/ABPadLockScreen/ABPadLockScreenView.m
+++ b/ABPadLockScreen/ABPadLockScreenView.m
@@ -26,6 +26,7 @@
 
 #define animationLength 0.15
 #define IS_IPHONE5 ([UIScreen mainScreen].bounds.size.height==568)
+#define IS_IOS6_OR_LOWER (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1)
 
 @interface ABPadLockScreenView()
 
@@ -341,10 +342,10 @@
 
 - (void)layoutTitleArea
 {
-    CGFloat top = 75;
+    CGFloat top = 65;
 	if(!IS_IPHONE5)
 	{
-		top = 20;
+		top = IS_IOS6_OR_LOWER ? 10 : 25;
 	}
     self.enterPasscodeLabel.frame = CGRectMake(([self correctWidth]/2) - 100, top, 200, 23);
     [self.contentView addSubview:self.enterPasscodeLabel];


### PR DESCRIPTION
I fixed this issue
https://github.com/abury/ABPadLockScreen/issues/26
One of the problem was that Abstract VC initializes ScreenView with frame instead of bounds, which make it appear lower 20 pixels in iOS 6.
Also, in ScreenView top var should have different size due to taking in account the status bar (20pt) height in iOS 6.
And finally, I changed a couple of value just a little bit so would ScreenView appear more center aligned vertically.
Hope it's OK.
