### PR TITLE
Allows simple ping to have a user-customizable number of decimal digits

### DIFF
--- a/ABPadLockScreen/ABPadLockScreenAbstractViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenAbstractViewController.m
@@ -182,7 +182,7 @@
 #pragma mark - Button Methods
 - (void)newPinSelected:(NSInteger)pinNumber
 {
-    if (!self.isComplexPin && [self.currentPin length] >= 4)
+    if (!self.isComplexPin && [self.currentPin length] >= SIMPLE_PIN_LENGTH)
     {
         return;
     }
@@ -208,7 +208,7 @@
 			[lockScreenView showOKButton:YES animated:YES completion:nil];
 		}
     }
-    else if (!self.isComplexPin && [self.currentPin length] == 4)
+    else if (!self.isComplexPin && [self.currentPin length] == SIMPLE_PIN_LENGTH)
     {
         [lockScreenView.digitsArray.lastObject setSelected:YES animated:YES completion:nil];
         [self processPin];

--- a/ABPadLockScreen/ABPadLockScreenView.h
+++ b/ABPadLockScreen/ABPadLockScreenView.h
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#define SIMPLE_PIN_LENGTH 4
+
 @class ABPinSelectionView;
 
 @interface ABPadLockScreenView : UIView

--- a/ABPadLockScreen/ABPadLockScreenView.m
+++ b/ABPadLockScreen/ABPadLockScreenView.m
@@ -162,10 +162,10 @@
 	
     if (!_digitsArray)
     {
-		//Simple pin code is always 4 characters.
-        NSMutableArray *array = [NSMutableArray arrayWithCapacity:4];
+		//Simple pin code is always (SIMPLE_PIN_LENGTH) characters.
+        NSMutableArray *array = [NSMutableArray arrayWithCapacity:SIMPLE_PIN_LENGTH];
         
-        for (NSInteger i = 0; i < 4; i++)
+        for (NSInteger i = 0; i < SIMPLE_PIN_LENGTH; i++)
         {
             ABPinSelectionView *view = [[ABPinSelectionView alloc] initWithFrame:CGRectZero];
             [array addObject:view];
@@ -417,7 +417,7 @@
 	else
 	{
 		CGFloat pinPadding = 25;
-		CGFloat pinRowWidth = (ABPinSelectionViewWidth * 4) + (pinPadding * 3);
+		CGFloat pinRowWidth = (ABPinSelectionViewWidth * SIMPLE_PIN_LENGTH) + (pinPadding * (SIMPLE_PIN_LENGTH - 1));
 		
 		CGFloat selectionViewLeft = ([self correctWidth]/2) - (pinRowWidth/2);
 		


### PR DESCRIPTION
Instead of forcing "simple pin" to 4 digits only, this uses a constant so developers can create apps that require pins shorter or longer.

For example, an app we're developing (for internal use only) requires us to type a 6-digits pin, for controlling a remote device.
