### PR TITLE
ABPadLockScreenSetupViewController init method fix

### DIFF
--- a/ABPadLockScreen/ABPadLockScreenSetupViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenSetupViewController.m
@@ -46,6 +46,8 @@
     if (self)
     {
         self.delegate = delegate;
+        _setupScreenDelegate = delegate;
+        _enteredPin = nil;
     }
     return self;
 }


### PR DESCRIPTION
don't setting setup screen delegate fix in initWithDelegate method