### PR TITLE
Ignored appearances and enter passcode label text setter

### DIFF
--- a/ABPadLockScreen/ABPadButton.m
+++ b/ABPadLockScreen/ABPadButton.m
@@ -115,8 +115,10 @@
     self.layer.borderColor = [self.borderColor CGColor];
     self.numberLabel.textColor = self.textColor;
     self.numberLabel.highlightedTextColor = self.hightlightedTextColor;
+    self.numberLabel.font = self.numberLabelFont;
     self.lettersLabel.textColor = self.textColor;
     self.lettersLabel.highlightedTextColor = self.hightlightedTextColor;
+    self.lettersLabel.font = self.letterLabelFont;
 }
 
 - (void)performLayout

--- a/ABPadLockScreen/ABPadLockScreenAbstractViewController.h
+++ b/ABPadLockScreen/ABPadLockScreenAbstractViewController.h
@@ -47,6 +47,7 @@
 - (void)setSubtitleText:(NSString *)text;
 - (void)setCancelButtonText:(NSString *)text;
 - (void)setDeleteButtonText:(NSString *)text;
+- (void)setEnterPasscodeLabelText:(NSString *)text;
 
 - (void)cancelButtonDisabled:(BOOL)disabled;
 

--- a/ABPadLockScreen/ABPadLockScreenAbstractViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenAbstractViewController.m
@@ -151,6 +151,11 @@
     [lockScreenView.deleteButton sizeToFit];
 }
 
+- (void)setEnterPasscodeLabelText:(NSString *)text
+{
+    lockScreenView.enterPasscodeLabel.text = text;
+}
+
 - (void)setBackgroundView:(UIView *)backgroundView
 {
 	[lockScreenView setBackgroundView:backgroundView];

--- a/ABPadLockScreen/ABPadLockScreenSetupViewController.h
+++ b/ABPadLockScreen/ABPadLockScreenSetupViewController.h
@@ -35,6 +35,8 @@
 
 @property (nonatomic, weak, readonly) id<ABPadLockScreenSetupViewControllerDelegate> setupScreenDelegate;
 @property (nonatomic, strong, readonly) NSString *subtitleLabelText;
+@property (nonatomic, strong) NSString *pinNotMatchedText;
+@property (nonatomic, strong) NSString *pinConfirmationText;
 
 - (instancetype)initWithDelegate:(id<ABPadLockScreenSetupViewControllerDelegate>)delegate;
 - (instancetype)initWithDelegate:(id<ABPadLockScreenSetupViewControllerDelegate>)delegate complexPin:(BOOL)complexPin;

--- a/ABPadLockScreen/ABPadLockScreenSetupViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenSetupViewController.m
@@ -46,6 +46,7 @@
     if (self)
     {
         self.delegate = delegate;
+        [self setDefaultTexts];
     }
     return self;
 }
@@ -58,6 +59,7 @@
         self.delegate = delegate;
         _setupScreenDelegate = delegate;
         _enteredPin = nil;
+        [self setDefaultTexts];
     }
     return self;
 }
@@ -73,6 +75,12 @@
         });
     }
     return self;
+}
+
+- (void)setDefaultTexts
+{
+    _pinNotMatchedText = NSLocalizedString(@"Pincode did not match.", @"");
+    _pinConfirmationText = NSLocalizedString(@"Re-enter your new pincode", @"");
 }
 
 #pragma mark -
@@ -100,7 +108,7 @@
 {
     self.enteredPin = self.currentPin;
     self.currentPin = @"";
-    [lockScreenView updateDetailLabelWithString:NSLocalizedString(@"Re-enter your new pincode", @"") animated:YES completion:nil];
+    [lockScreenView updateDetailLabelWithString:self.pinConfirmationText animated:YES completion:nil];
     [lockScreenView resetAnimated:YES];
 }
          
@@ -115,7 +123,7 @@
     }
     else
     {
-        [lockScreenView updateDetailLabelWithString:NSLocalizedString(@"Pincode did not match.", @"") animated:YES completion:nil];
+        [lockScreenView updateDetailLabelWithString:self.pinNotMatchedText animated:YES completion:nil];
 		[lockScreenView animateFailureNotification];
         [lockScreenView resetAnimated:YES];
         self.enteredPin = nil;

--- a/ABPadLockScreen/ABPadLockScreenView.h
+++ b/ABPadLockScreen/ABPadLockScreenView.h
@@ -28,7 +28,7 @@
 
 @property (nonatomic, strong) UIFont *enterPasscodeLabelFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIFont *detailLabelFont UI_APPEARANCE_SELECTOR;
-@property (nonatomic, strong) UIFont *cancelLabelFont UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIFont *deleteCancelLabelFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor *labelColor UI_APPEARANCE_SELECTOR;
 
 @property (nonatomic, strong) UIView* backgroundView;

--- a/ABPadLockScreen/ABPadLockScreenView.h
+++ b/ABPadLockScreen/ABPadLockScreenView.h
@@ -28,6 +28,7 @@
 
 @property (nonatomic, strong) UIFont *enterPasscodeLabelFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIFont *detailLabelFont UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIFont *cancelLabelFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor *labelColor UI_APPEARANCE_SELECTOR;
 
 @property (nonatomic, strong) UIView* backgroundView;

--- a/ABPadLockScreen/ABPadLockScreenView.m
+++ b/ABPadLockScreen/ABPadLockScreenView.m
@@ -371,6 +371,8 @@
     self.detailLabel.font = self.detailLabelFont;
     
     [self.cancelButton setTitleColor:self.labelColor forState:UIControlStateNormal];
+    self.cancelButton.titleLabel.font = self.cancelLabelFont;
+    
     [self.deleteButton setTitleColor:self.labelColor forState:UIControlStateNormal];
 	[self.okButton setTitleColor:self.labelColor forState:UIControlStateNormal];
 }
@@ -398,7 +400,7 @@
 		top = NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_6_1 ? 30 : 80;;
 	}
 	
-    self.enterPasscodeLabel.frame = CGRectMake(([self correctWidth]/2) - 100, top, 200, 23);
+    self.enterPasscodeLabel.frame = CGRectMake(50, top, [self correctWidth] - 100, 23);
     [self.contentView addSubview:self.enterPasscodeLabel];
 	
 	CGFloat pinSelectionTop = self.enterPasscodeLabel.frame.origin.y + self.enterPasscodeLabel.frame.size.height + 17.5;

--- a/ABPadLockScreen/ABPadLockScreenView.m
+++ b/ABPadLockScreen/ABPadLockScreenView.m
@@ -371,9 +371,11 @@
     self.detailLabel.font = self.detailLabelFont;
     
     [self.cancelButton setTitleColor:self.labelColor forState:UIControlStateNormal];
-    self.cancelButton.titleLabel.font = self.cancelLabelFont;
+    self.cancelButton.titleLabel.font = self.deleteCancelLabelFont;
     
     [self.deleteButton setTitleColor:self.labelColor forState:UIControlStateNormal];
+    self.deleteButton.titleLabel.font = self.deleteCancelLabelFont;
+
 	[self.okButton setTitleColor:self.labelColor forState:UIControlStateNormal];
 }
 

--- a/ABPadLockScreen/ABPadLockScreenView.m
+++ b/ABPadLockScreen/ABPadLockScreenView.m
@@ -222,7 +222,7 @@
 
 	CGFloat pinSelectionTop = self.enterPasscodeLabel.frame.origin.y + self.enterPasscodeLabel.frame.size.height + 17.5;
 	
-    self.detailLabel.frame = CGRectMake(([self correctWidth]/2) - 100, pinSelectionTop + 30, 200, 23);
+    self.detailLabel.frame = CGRectMake(([self correctWidth]/2) - 150, pinSelectionTop + 30, 300, 23);
 }
 
 - (void)lockViewAnimated:(BOOL)animated completion:(void (^)(BOOL finished))completion
@@ -402,7 +402,7 @@
 		top = NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_6_1 ? 30 : 80;;
 	}
 	
-    self.enterPasscodeLabel.frame = CGRectMake(50, top, [self correctWidth] - 100, 23);
+    self.enterPasscodeLabel.frame = CGRectMake(([self correctWidth]/2) - 150, top, 300, 23);
     [self.contentView addSubview:self.enterPasscodeLabel];
 	
 	CGFloat pinSelectionTop = self.enterPasscodeLabel.frame.origin.y + self.enterPasscodeLabel.frame.size.height + 17.5;
@@ -431,7 +431,7 @@
 		}
 	}
 	
-    self.detailLabel.frame = CGRectMake(([self correctWidth]/2) - 100, pinSelectionTop + 30, 200, 23);
+    self.detailLabel.frame = CGRectMake(([self correctWidth]/2) - 150, pinSelectionTop + 30, 300, 23);
     [self.contentView addSubview:self.detailLabel];
 }
 


### PR DESCRIPTION
`numberLabelFont` and `letterLabelFont` appearance properties wasn't used in `prepareApperance` method.

Also, you can now set the enter passcode label's text with a simple method.