### PR TITLE
Add pin validation feature

### DIFF
--- a/ABPadLockScreen/ABPadLockScreenAbstractViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenAbstractViewController.m
@@ -108,7 +108,7 @@
 	
 	if(color == nil)
 	{
-		color = lockScreenView.backgroundColor = [UIColor blackColor];
+		color = [UIColor blackColor];
 	}
 	
 	const CGFloat *componentColors = CGColorGetComponents(color.CGColor);

--- a/ABPadLockScreen/ABPadLockScreenSetupViewController.h
+++ b/ABPadLockScreen/ABPadLockScreenSetupViewController.h
@@ -37,6 +37,7 @@
 @property (nonatomic, strong, readonly) NSString *subtitleLabelText;
 @property (nonatomic, strong) NSString *pinNotMatchedText;
 @property (nonatomic, strong) NSString *pinConfirmationText;
+@property (nonatomic, strong) NSString *invalidPinText;
 
 - (instancetype)initWithDelegate:(id<ABPadLockScreenSetupViewControllerDelegate>)delegate;
 - (instancetype)initWithDelegate:(id<ABPadLockScreenSetupViewControllerDelegate>)delegate complexPin:(BOOL)complexPin;
@@ -48,5 +49,7 @@
 @required
 - (void)pinSet:(NSString *)pin padLockScreenSetupViewController:(ABPadLockScreenSetupViewController *)padLockScreenViewController;
 - (void)unlockWasCancelledForSetupViewController:(ABPadLockScreenAbstractViewController *)padLockScreenViewController;
+@optional
+- (BOOL)isValidPin:(NSString *)pin padLockScreenSetupViewController:(ABPadLockScreenSetupViewController *)padLockScreenViewController;
 
 @end

--- a/ABPadLockScreen/ABPadLockScreenSetupViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenSetupViewController.m
@@ -91,12 +91,18 @@
 {
     if (!self.enteredPin)
     {
-        [self startPinConfirmation];
+        [self validatePin];
     }
     else
     {
         [self validateConfirmedPin];
     }
+}
+
+- (void)invalidateCurrentPin
+{
+    self.enteredPin = nil;
+    self.currentPin = @"";
 }
 
 - (void)startPinConfirmation
@@ -106,7 +112,24 @@
     [lockScreenView updateDetailLabelWithString:self.pinConfirmationText animated:YES completion:nil];
     [lockScreenView resetAnimated:YES];
 }
-         
+
+- (void)validatePin
+{
+    BOOL isValidPin = YES;
+    if ([self.setupScreenDelegate respondsToSelector:@selector(isValidPin:padLockScreenSetupViewController:)])
+    {
+        isValidPin = [self.setupScreenDelegate isValidPin:self.currentPin padLockScreenSetupViewController:self];
+    }
+    if (isValidPin)
+    {
+        [self startPinConfirmation];
+    }
+    else
+    {
+        [self resetPinWithErrorString:self.invalidPinText];
+    }
+}
+
 - (void)validateConfirmedPin
 {
     if ([self.currentPin isEqualToString:self.enteredPin])
@@ -118,17 +141,21 @@
     }
     else
     {
-        [lockScreenView updateDetailLabelWithString:self.pinNotMatchedText animated:YES completion:nil];
-		[lockScreenView animateFailureNotification];
-        [lockScreenView resetAnimated:YES];
-        self.enteredPin = nil;
-        self.currentPin = @"";
-        
-        // viberate feedback
-        if (self.errorVibrateEnabled)
-        {
-            AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
-        }
+        [self resetPinWithErrorString:self.pinNotMatchedText];
+    }
+}
+
+- (void)resetPinWithErrorString:(NSString *)errorString {
+    [lockScreenView updateDetailLabelWithString:errorString animated:YES completion:nil];
+    [lockScreenView animateFailureNotification];
+    [lockScreenView resetAnimated:YES];
+    self.enteredPin = nil;
+    self.currentPin = @"";
+
+    // viberate feedback
+    if (self.errorVibrateEnabled)
+    {
+        AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
     }
 }
 

--- a/ABPadLockScreen/ABPadLockScreenSetupViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenSetupViewController.m
@@ -75,6 +75,7 @@
 {
     _pinNotMatchedText = NSLocalizedString(@"Pincode did not match.", @"");
     _pinConfirmationText = NSLocalizedString(@"Re-enter your new pincode", @"");
+    _invalidPinText = NSLocalizedString(@"Invalid pincode", @"");
 }
 
 #pragma mark -

--- a/ABPadLockScreen/ABPadLockScreenViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenViewController.m
@@ -123,13 +123,17 @@
     
     if (self.remainingAttempts > 1)
     {
-        [lockScreenView updateDetailLabelWithString:[NSString stringWithFormat:@"%ld %@", (long)self.remainingAttempts, self.pluralAttemptsLeftString]
-                                           animated:YES completion:nil];
+        if (self.pluralAttemptsLeftString) {
+            [lockScreenView updateDetailLabelWithString:[NSString stringWithFormat:@"%ld %@", (long)self.remainingAttempts, self.pluralAttemptsLeftString]
+                                               animated:YES completion:nil];
+        }
     }
     else if (self.remainingAttempts == 1)
     {
-        [lockScreenView updateDetailLabelWithString:[NSString stringWithFormat:@"%ld %@", (long)self.remainingAttempts, self.singleAttemptLeftString]
-                                           animated:YES completion:nil];
+        if (self.singleAttemptLeftString) {
+            [lockScreenView updateDetailLabelWithString:[NSString stringWithFormat:@"%ld %@", (long)self.remainingAttempts, self.singleAttemptLeftString]
+                                               animated:YES completion:nil];
+        }
     }
     else if (self.remainingAttempts == 0)
     {

--- a/ABPadLockScreenDemo/ABPadLockScreenDemo/Your Modules/ExampleViewController.m
+++ b/ABPadLockScreenDemo/ABPadLockScreenDemo/Your Modules/ExampleViewController.m
@@ -48,6 +48,7 @@
     ABPadLockScreenSetupViewController *lockScreen = [[ABPadLockScreenSetupViewController alloc] initWithDelegate:self complexPin:YES subtitleLabelText:@"You need a PIN to continue"];
     lockScreen.tapSoundEnabled = YES;
     lockScreen.errorVibrateEnabled = YES;
+    lockScreen.invalidPinText = @"Invalid pin";
 	
     lockScreen.modalPresentationStyle = UIModalPresentationFullScreen;
     lockScreen.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
@@ -124,6 +125,10 @@
 {
     [self dismissViewControllerAnimated:YES completion:nil];
     NSLog(@"Pin Setup Cnaclled");
+}
+
+- (BOOL)isValidPin:(NSString *)pin padLockScreenSetupViewController:(ABPadLockScreenSetupViewController *)padLockScreenViewController {
+    return ![pin isEqualToString:@"0000"];
 }
 
 @end

--- a/ABPadLockScreenSwiftDemo/ABPadLockScreenSwiftDemo/ViewController.swift
+++ b/ABPadLockScreenSwiftDemo/ABPadLockScreenSwiftDemo/ViewController.swift
@@ -50,6 +50,7 @@ class ViewController: UIViewController, ABPadLockScreenSetupViewControllerDelega
     
     @IBAction func setPinSelected(sender: AnyObject) {
         let lockSetupScreen = ABPadLockScreenSetupViewController(delegate: self, complexPin: false, subtitleLabelText: "Select a pin")
+        lockSetupScreen.invalidPinText = "Invalid pin"
         lockSetupScreen.tapSoundEnabled = true
         lockSetupScreen.errorVibrateEnabled = true
         lockSetupScreen.modalPresentationStyle = UIModalPresentationStyle.FullScreen
@@ -66,6 +67,10 @@ class ViewController: UIViewController, ABPadLockScreenSetupViewControllerDelega
     
     func unlockWasCancelledForSetupViewController(padLockScreenViewController: ABPadLockScreenAbstractViewController!) {
         dismissViewControllerAnimated(true, completion: nil)
+    }
+
+    func isValidPin(pin: String!, padLockScreenSetupViewController padLockScreenViewController: ABPadLockScreenSetupViewController!) -> Bool {
+        return pin != "0000"
     }
     
     //MARK: Lock Screen Delegate


### PR DESCRIPTION
It's now possible to invalidate too simple pincode like _0000_ or _1234_.

Just set the _invalidPinText_ property and implement _isValidPin:padLockScreenSetupViewController:_ delegate method.
