### PR TITLE
Adding a forgot button 

### DIFF
--- a/ABPadLockScreen/ABPadButton.m
+++ b/ABPadLockScreen/ABPadButton.m
@@ -126,7 +126,7 @@
     self.selectedView.frame = CGRectMake(0, 0, self.frame.size.width, self.frame.size.height);
     [self addSubview:self.selectedView];
     
-    self.numberLabel.frame = CGRectMake(0, self.frame.size.height / 5, self.frame.size.width, self.frame.size.height/2.5);
+    self.numberLabel.frame = CGRectMake(0, self.frame.size.height / 5, self.frame.size.width, self.frame.size.height/2.5f);
     [self addSubview:self.numberLabel];
 	
 	if(self.tag == 0)

--- a/ABPadLockScreen/ABPadLockScreenAbstractViewController.h
+++ b/ABPadLockScreen/ABPadLockScreenAbstractViewController.h
@@ -50,6 +50,7 @@
 - (void)setEnterPasscodeLabelText:(NSString *)text;
 
 - (void)cancelButtonDisabled:(BOOL)disabled;
+- (void)forgotButtonDisabled:(BOOL)disabled;
 
 - (void)setBackgroundView:(UIView*)backgroundView;
 

--- a/ABPadLockScreen/ABPadLockScreenAbstractViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenAbstractViewController.m
@@ -32,6 +32,7 @@
 - (void)setUpButtonMapping;
 - (void)buttonSelected:(UIButton *)sender;
 - (void)deleteButtonSelected:(UIButton *)sender;
+- (void)forgotButtonSelected:(UIButton *)sender;
 - (void)okButtonSelected:(UIButton *)sender;
 
 @end
@@ -83,6 +84,7 @@
     
     [self setUpButtonMapping];
     [lockScreenView.deleteButton addTarget:self action:@selector(deleteButtonSelected:) forControlEvents:UIControlEventTouchUpInside];
+    [lockScreenView.forgotButton addTarget:self action:@selector(forgotButtonSelected:) forControlEvents:UIControlEventTouchUpInside];
 	[lockScreenView.okButton addTarget:self action:@selector(okButtonSelected:) forControlEvents:UIControlEventTouchUpInside];
 }
 
@@ -160,6 +162,13 @@
     [lockScreenView.deleteButton sizeToFit];
 }
 
+- (void)setForgotButtonText:(NSString *)text
+{
+    [lockScreenView.forgotButton setTitle:text forState:UIControlStateNormal];
+    [lockScreenView.forgotButton sizeToFit];
+}
+
+
 - (void)setEnterPasscodeLabelText:(NSString *)text
 {
     lockScreenView.enterPasscodeLabel.text = text;
@@ -188,6 +197,16 @@
 - (void)cancelButtonDisabled:(BOOL)disabled
 {
     lockScreenView.cancelButtonDisabled = disabled;
+}
+
+- (void)forgotButtonDisabled:(BOOL)disabled
+{
+    lockScreenView.forgotButtonDisabled = disabled;
+}
+
+- (void)processForgot
+{
+    //Subclass to provide concrete implementation
 }
 
 - (void)processPin
@@ -271,6 +290,11 @@
 - (void)deleteButtonSelected:(UIButton *)sender
 {
     [self deleteFromPin];
+}
+
+- (void)forgotButtonSelected:(UIButton *)sender
+{
+    [self processForgot];
 }
 
 - (void)okButtonSelected:(UIButton *)sender

--- a/ABPadLockScreen/ABPadLockScreenSetupViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenSetupViewController.m
@@ -54,6 +54,7 @@
         _setupScreenDelegate = delegate;
         _enteredPin = nil;
         [self setDefaultTexts];
+        [self forgotButtonDisabled:YES];
     }
     return self;
 }
@@ -65,7 +66,7 @@
     {
         _subtitleLabelText = subtitleLabelText;
         dispatch_async(dispatch_get_main_queue(), ^{
-            [lockScreenView updateDetailLabelWithString:_subtitleLabelText animated:NO completion:nil];
+            [lockScreenView updateDetailLabelWithString:self->_subtitleLabelText animated:NO completion:nil];
         });
     }
     return self;

--- a/ABPadLockScreen/ABPadLockScreenView.h
+++ b/ABPadLockScreen/ABPadLockScreenView.h
@@ -31,11 +31,13 @@
 @property (nonatomic, strong) UIFont *enterPasscodeLabelFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIFont *detailLabelFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIFont *deleteCancelLabelFont UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIFont *forgotLabelFont UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor *labelColor UI_APPEARANCE_SELECTOR;
 
 @property (nonatomic, strong) UIView* backgroundView;
 
 @property (nonatomic, assign) BOOL cancelButtonDisabled;
+@property (nonatomic, assign) BOOL forgotButtonDisabled;
 
 @property (nonatomic, strong, readonly) UILabel *enterPasscodeLabel;
 @property (nonatomic, strong, readonly) UILabel *detailLabel;
@@ -56,6 +58,7 @@
 
 @property (nonatomic, strong, readonly) UIButton *cancelButton;
 @property (nonatomic, strong, readonly) UIButton *deleteButton;
+@property (nonatomic, strong, readonly) UIButton *forgotButton;
 
 @property (nonatomic, strong, readonly) UIButton *okButton;
 
@@ -73,6 +76,7 @@
 
 - (void)showCancelButtonAnimated:(BOOL)animated completion:(void (^)(BOOL finished))completion;
 - (void)showDeleteButtonAnimated:(BOOL)animated completion:(void (^)(BOOL finished))completion;
+- (void)showForgotButtonAnimated:(BOOL)show animated:(BOOL)animated completion:(void (^)(BOOL finished))completion;
 - (void)showOKButton:(BOOL)show animated:(BOOL)animated completion:(void (^)(BOOL finished))completion;
 
 - (void)updateDetailLabelWithString:(NSString *)string animated:(BOOL)animated completion:(void (^)(BOOL finished))completion;

--- a/ABPadLockScreen/ABPadLockScreenView.m
+++ b/ABPadLockScreen/ABPadLockScreenView.m
@@ -24,7 +24,7 @@
 #import "ABPadButton.h"
 #import "ABPinSelectionView.h"
 
-#define animationLength 0.15
+#define animationLength 0.15f
 #define IS_IPHONE5 ([UIScreen mainScreen].bounds.size.height==568)
 #define IS_IOS6_OR_LOWER (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1)
 
@@ -123,6 +123,11 @@
 		_deleteButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
         _deleteButton.alpha = 0.0f;
         
+        _forgotButton = [UIButton buttonWithType:buttonType];
+        [_forgotButton setTitle:NSLocalizedString(@"Forgot?", @"") forState:UIControlStateNormal];
+        _forgotButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
+        _forgotButton.alpha = 0.0f; //1.0f
+        
 		_okButton = [UIButton buttonWithType:buttonType];
 		[_okButton setTitle:NSLocalizedString(@"OK", @"") forState:UIControlStateNormal];
 		_okButton.alpha = 0.0f;
@@ -195,6 +200,14 @@
     } animated:animated completion:completion];
 }
 
+- (void)showForgotButtonAnimated:(BOOL)show animated:(BOOL)animated completion:(void (^)(BOOL finished))completion
+{
+    __weak ABPadLockScreenView *weakSelf = self;
+    [self performAnimations:^{
+        weakSelf.forgotButton.alpha = show ? 1.0f : 0.0f;
+    } animated:animated completion:completion];
+}
+
 - (void)showOKButton:(BOOL)show animated:(BOOL)animated completion:(void (^)(BOOL finished))completion
 {
 	__weak ABPadLockScreenView *weakSelf = self;
@@ -215,7 +228,7 @@
     
     self.detailLabel.text = string;
 
-	CGFloat pinSelectionTop = self.enterPasscodeLabel.frame.origin.y + self.enterPasscodeLabel.frame.size.height + 17.5;
+	CGFloat pinSelectionTop = self.enterPasscodeLabel.frame.origin.y + self.enterPasscodeLabel.frame.size.height + 17.5f;
 	
     self.detailLabel.frame = CGRectMake(([self correctWidth]/2) - 150, pinSelectionTop + 30, 300, 23);
 }
@@ -285,6 +298,7 @@
     }
     
     [self showCancelButtonAnimated:animated completion:nil];
+    [self showForgotButtonAnimated:animated animated:NO completion:nil];
 	[self showOKButton:NO animated:animated completion:nil];
 	
 	[self updatePinTextfieldWithLength:0];
@@ -375,6 +389,9 @@
     
     [self.deleteButton setTitleColor:self.labelColor forState:UIControlStateNormal];
     self.deleteButton.titleLabel.font = self.deleteCancelLabelFont;
+    
+    [self.forgotButton setTitleColor:self.labelColor forState:UIControlStateNormal];
+    self.forgotButton.titleLabel.font = self.forgotLabelFont;
 
 	[self.okButton setTitleColor:self.labelColor forState:UIControlStateNormal];
 }
@@ -399,13 +416,13 @@
 	
 	if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
 	{
-		top = NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_6_1 ? 30 : 80;;
+		top = NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_6_1 ? 30 : 80;
 	}
-	
+    
     self.enterPasscodeLabel.frame = CGRectMake(([self correctWidth]/2) - 150, top, 300, 23);
     [self.contentView addSubview:self.enterPasscodeLabel];
 	
-	CGFloat pinSelectionTop = self.enterPasscodeLabel.frame.origin.y + self.enterPasscodeLabel.frame.size.height + 17.5;
+	CGFloat pinSelectionTop = self.enterPasscodeLabel.frame.origin.y + self.enterPasscodeLabel.frame.size.height + 17.5f;
 
 	if(self.isComplexPin)
 	{
@@ -442,7 +459,7 @@
     
     CGFloat buttonRowWidth = (ABPadButtonWidth * 3) + (horizontalButtonPadding * 2);
     
-    CGFloat lefButtonLeft = ([self correctWidth]/2) - (buttonRowWidth/2) + 0.5;
+    CGFloat lefButtonLeft = ([self correctWidth]/2) - (buttonRowWidth/2) + 0.5f;
     CGFloat centerButtonLeft = lefButtonLeft + ABPadButtonWidth + horizontalButtonPadding;
     CGFloat rightButtonLeft = centerButtonLeft + ABPadButtonWidth + horizontalButtonPadding;
     
@@ -489,6 +506,25 @@
     
     self.deleteButton.frame = deleteCancelButtonFrame;
     [self.contentView addSubview:self.deleteButton];
+    
+    CGRect forgotButtonFrame = CGRectMake(lefButtonLeft, zeroRowTop + ABPadButtonHeight + 25, ABPadButtonWidth, 20);
+    if(!IS_IPHONE5)
+    {
+        //Bring it higher for small device screens
+        forgotButtonFrame = CGRectMake(lefButtonLeft, zeroRowTop + ABPadButtonHeight - 20, ABPadButtonWidth, 20);
+    }
+    
+    if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
+    {
+        //Center it with zero button
+        forgotButtonFrame = CGRectMake(lefButtonLeft, zeroRowTop + (ABPadButtonHeight / 2 - 10), ABPadButtonWidth, 20);
+    }
+    
+    if (!self.forgotButtonDisabled) {
+        self.forgotButton.frame = forgotButtonFrame;
+        [self.contentView addSubview:self.forgotButton];
+    }
+
 }
 
 - (void)setUpButton:(UIButton *)button left:(CGFloat)left top:(CGFloat)top

--- a/ABPadLockScreen/ABPadLockScreenViewController.h
+++ b/ABPadLockScreen/ABPadLockScreenViewController.h
@@ -52,6 +52,11 @@
 @required
 
 /**
+ *  Called when the forgot
+ */
+- (void)forgotPinForPadLockScreenViewController:(ABPadLockScreenViewController *)padLockScreenViewController;
+
+/**
  Called when pin validation is needed
  */
 - (BOOL)padLockScreenViewController:(ABPadLockScreenViewController *)padLockScreenViewController validatePin:(NSString*)pin;

--- a/ABPadLockScreen/ABPadLockScreenViewController.m
+++ b/ABPadLockScreen/ABPadLockScreenViewController.m
@@ -92,6 +92,16 @@
     [lockScreenView.cancelButton addTarget:self action:@selector(cancelButtonSelected:) forControlEvents:UIControlEventTouchUpInside];
 }
 
+#pragma mark - Forgot
+#pragma mark - Pin Processing
+- (void)processForgot
+{
+    if ([self.lockScreenDelegate respondsToSelector:@selector(forgotPinForPadLockScreenViewController:)])
+    {
+        [self.lockScreenDelegate forgotPinForPadLockScreenViewController:self];
+    }
+}
+
 #pragma mark -
 #pragma mark - Pin Processing
 - (void)processPin
@@ -125,6 +135,8 @@
     {
         [lockScreenView updateDetailLabelWithString:[NSString stringWithFormat:@"%ld %@", (long)self.remainingAttempts, self.pluralAttemptsLeftString]
                                            animated:YES completion:nil];
+        
+        [lockScreenView showForgotButtonAnimated:YES animated:YES completion:nil];
     }
     else if (self.remainingAttempts == 1)
     {

--- a/ABPadLockScreen/ABPinSelectionView.m
+++ b/ABPadLockScreen/ABPinSelectionView.m
@@ -23,7 +23,7 @@
 #import "ABPinSelectionView.h"
 #import <QuartzCore/QuartzCore.h>
 
-#define animationLength 0.15
+#define animationLength 0.15f
 
 @interface ABPinSelectionView()
 

--- a/ABPadLockScreenDemo/ABPadLockScreenDemo/Your Modules/ExampleViewController.m
+++ b/ABPadLockScreenDemo/ABPadLockScreenDemo/Your Modules/ExampleViewController.m
@@ -87,6 +87,34 @@
 #pragma mark -
 #pragma mark - ABLockScreenDelegate Methods
 
+- (void)forgotPinForPadLockScreenViewController:(ABPadLockScreenViewController *)padLockScreenViewController
+{
+    NSLog(@"Forgot pin");
+    
+    UIAlertController *signOutAlertController = [UIAlertController alertControllerWithTitle:@"Forgot your PIN?"
+                                                                                    message:@"Please try again, or tap here to reset."
+                                                                             preferredStyle:UIAlertControllerStyleAlert];
+    
+    UIAlertAction *signOutCancelAction = [UIAlertAction actionWithTitle:@"Cancel"
+                                                                  style:UIAlertActionStyleCancel
+                                                                handler:^(UIAlertAction *action) {
+        NSLog(@"Cancel action");
+        // Dismiss the alert controller.
+    }];
+    
+    UIAlertAction *signOutOkAction = [UIAlertAction actionWithTitle:@"Sign Out"
+                                                               style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+        NSLog(@"Sign out action");
+        // Log out the user out for example
+    }];
+    
+    [signOutAlertController addAction:signOutCancelAction];
+    [signOutAlertController addAction:signOutOkAction];
+    
+    [padLockScreenViewController presentViewController:signOutAlertController animated:YES completion:nil];
+    
+}
+
 - (BOOL)padLockScreenViewController:(ABPadLockScreenViewController *)padLockScreenViewController validatePin:(NSString*)pin;
 {
 	NSLog(@"Validating pin %@", pin);


### PR DESCRIPTION
Adding a forgot button to the ABPadLockScreenAbstractViewController. There was a use case when a user actually forgets their passcode, but is still within the limit of the number of attempts. The ability to use a mechanism to teardown the app and reset it if the user forgot their passcode.

The forgot button appears after the first failed attempt of the passcode. Honors UI_APPEARANCE_SELECTOR for customization. Also includes a required ABLockScreenDelegate protocol method forgotPinForPadLockScreenViewController: to handle the button event. 

Updated the demo project.